### PR TITLE
Make languages configurable

### DIFF
--- a/src/app/config/config.component.html
+++ b/src/app/config/config.component.html
@@ -39,6 +39,16 @@
       </clr-checkbox-wrapper>
     </clr-checkbox-container>
   </form>
+
+  <form [formGroup]="languagesForm">
+    <h3>Languages</h3>
+    <div *ngFor="let lang of languageCommandService.getAllLanguageKeys()">
+      <label>
+        <input type="checkbox" [formControlName]="lang" />
+        {{ lang }}
+      </label>
+    </div>
+  </form>
   <button type="button" class="btn btn-outline" (click)="storeSettings()">
     Save
   </button>

--- a/src/app/config/config.component.ts
+++ b/src/app/config/config.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostListener } from '@angular/core';
 import { ScoreService } from '../services/score.service';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { LanguageCommandService } from '../terminals/bashbrawl/languages/language-command.service';
 
 export class Cooldown {
   cooldown: string;
@@ -23,6 +24,8 @@ export class ConfigComponent {
   healthy = false;
   healthCheckPerformed = false;
 
+  public languagesForm: FormGroup = new FormGroup({});
+
   public settingsForm: FormGroup = new FormGroup(
     {
       server: new FormControl<string | null>(null, [Validators.required]),
@@ -39,7 +42,10 @@ export class ConfigComponent {
     },
   );
 
-  constructor(private scoreService: ScoreService) {
+  constructor(
+    private scoreService: ScoreService,
+    public languageCommandService: LanguageCommandService,
+  ) {
     this.badgeScanningMode = localStorage.getItem('badge_scanner')
       ? true
       : false;
@@ -52,6 +58,15 @@ export class ConfigComponent {
       server: localStorage.getItem('score_server'),
       badge_scanner: this.badgeScanningMode,
       disable_imprint: this.disableImprint,
+    });
+
+    this.languageCommandService.getAllLanguageKeys().forEach((lang) => {
+      let enabled = true;
+      let configEnabled = localStorage.getItem('enabled_' + lang);
+      if (configEnabled && configEnabled == 'false') {
+        enabled = false;
+      }
+      this.languagesForm.addControl(lang, new FormControl(enabled));
     });
 
     // in normal mode display the
@@ -93,6 +108,11 @@ export class ConfigComponent {
     } else {
       localStorage.removeItem('disable_imprint');
     }
+
+    this.languageCommandService.getAllLanguageKeys().forEach((lang) => {
+      localStorage.setItem('enabled_' + lang, this.languagesForm.value[lang]);
+    });
+
     window.location.reload();
   }
 

--- a/src/app/config/config.component.ts
+++ b/src/app/config/config.component.ts
@@ -62,7 +62,7 @@ export class ConfigComponent {
 
     this.languageCommandService.getAllLanguageKeys().forEach((lang) => {
       let enabled = true;
-      let configEnabled = localStorage.getItem('enabled_' + lang);
+      const configEnabled = localStorage.getItem('enabled_' + lang);
       if (configEnabled && configEnabled == 'false') {
         enabled = false;
       }

--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -105,7 +105,7 @@ export class HomeComponent implements OnInit {
   }
 
   getBrawlLanguages() {
-    return this.languageCommandService.getLanguageNames();
+    return this.languageCommandService.getLanguageNames().slice(0, 5);
   }
 
   setLargeTerminal() {

--- a/src/app/terminals/bashbrawl/bashbrawlterminal.component.ts
+++ b/src/app/terminals/bashbrawl/bashbrawlterminal.component.ts
@@ -524,7 +524,7 @@ export class BashbrawlterminalComponent implements OnInit, AfterViewInit {
 
   async displayAvailableLanguages(incluedAll: boolean = true) {
     let languages = this.languageCommandService
-      .getLanguageKeys()
+      .getEnabledLanguageKeys()
       .sort((a, b) => {
         return a.toLowerCase() > b.toLowerCase() ? 1 : -1;
       });
@@ -710,7 +710,7 @@ export class BashbrawlterminalComponent implements OnInit, AfterViewInit {
   }
 
   async selectLanguage(language: string) {
-    let languages = this.languageCommandService.getLanguageKeys();
+    let languages = this.languageCommandService.getEnabledLanguageKeys();
     languages = languages.map((el) => {
       return el.toLowerCase();
     });

--- a/src/app/terminals/bashbrawl/languages/language-command.service.ts
+++ b/src/app/terminals/bashbrawl/languages/language-command.service.ts
@@ -95,7 +95,7 @@ export class LanguageCommandService {
   }
 
   isEnabled(language: string): boolean {
-    let configEnabled = localStorage.getItem('enabled_' + language);
+    const configEnabled = localStorage.getItem('enabled_' + language);
 
     if (configEnabled && configEnabled == 'false') {
       return false;

--- a/src/app/terminals/bashbrawl/languages/language-command.service.ts
+++ b/src/app/terminals/bashbrawl/languages/language-command.service.ts
@@ -45,7 +45,7 @@ export class LanguageCommandService {
       });
     } else {
       // Loop through each language's command list
-      for (const lang in this.commands) {
+      for (const lang of this.getEnabledLanguageKeys()) {
         // Iterate over each command or command array in the command list
         this.getLanguageById(lang).cmds.forEach((command) => {
           // If command is an array, check if the trimmed command matches any command in the array
@@ -63,23 +63,44 @@ export class LanguageCommandService {
 
   getLanguageNames(): string[] {
     const languages: string[] = [];
-    Object.values(this.commands).forEach((element) => {
-      languages.push(element.name);
+    this.getEnabledLanguageKeys().forEach((element) => {
+      languages.push(this.getLanguageNameById(element));
     });
     return languages;
   }
 
-  getLanguageKeys() {
+  getAllLanguageKeys(): string[] {
     return Object.keys(this.commands);
   }
 
-  getLanguageById(language: string) {
+  getEnabledLanguageKeys(): string[] {
+    const languages: string[] = [];
+    Object.keys(this.commands).forEach((element) => {
+      if (this.isEnabled(element)) {
+        languages.push(element);
+      }
+    });
+
+    return languages;
+  }
+
+  getLanguageById(language: string): LanguageConfig {
     return this.commands[language] ?? {};
   }
 
-  getLanguageNameById(language: string) {
-    return this.getLanguageKeys().includes(language)
+  getLanguageNameById(language: string): string {
+    return this.getAllLanguageKeys().includes(language)
       ? this.getLanguageById(language).name
       : language.toUpperCase();
+  }
+
+  isEnabled(language: string): boolean {
+    let configEnabled = localStorage.getItem('enabled_' + language);
+
+    if (configEnabled && configEnabled == 'false') {
+      return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
fixes https://github.com/jggoebel/bashbrawl/issues/11
by making languages configurable.

On the `/config` page the desired languages can be enabled or disabled. This will be stored inside the local storage.
Also we now only display a maximum of 5 languages in the game menu